### PR TITLE
📦 NEW: Add CFFormat Github Actions workflow

### DIFF
--- a/.github/workflows/cfformat.yml
+++ b/.github/workflows/cfformat.yml
@@ -1,0 +1,34 @@
+name: CFFormat
+
+on:
+  push:
+    branches-ignore:
+      - "main"
+      - "master"
+      - "development"
+    paths:
+      - '**.cfc' # Only run if *.cfc files are modified
+  pull_request:
+    branches:
+      - main
+      - master
+      - development
+    paths:
+      - '**.cfc' # Only run if *.cfc files are modified
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Run CFFormat
+        uses: Ortus-Solutions/commandbox-action@v1
+        with:
+          cmd: cfformat run path=commands,includes,ModuleConfig.cfc --overwrite
+
+      - name: Commit Format Changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "👌 IMPROVE: Auto-format cfcs via cfformat"


### PR DESCRIPTION
Whoop whoop! Here's a CFFormat workflow to keep your `.cfc` files SUPER neat :bed: and tidy :broom:.

**Suggestion:** Before merging :hammer:  this PR, run `box cfformat settings wizard` to walk through the CFFormat options and generate a `.cfformat.json` file to specify exactly how CFFormat should format your CFML. If you'd rather not take the time (the wizard :mage: can be a little lengthy), you can use the [.cfformat.json file from the Ortus Coding Standards](https://github.com/Ortus-Solutions/coding-standards/blob/master/.cfformat.json).

Of course, you can skip all that and just merge this PR. CFFormat is pretty good by default - no `.cfformat.json` required, as long as you're not picky about spaces around leading commas. :wink: 